### PR TITLE
Swapped GPIO pins, added WOL and convert executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required (VERSION 2.6)
+project (IRController)
+add_executable(convert convert.cxx)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+This project is a fork from the @mdhiggins [project](https://github.com/mdhiggins/ESP8266-HTTP-IR-Blaster/), with a few small tweaks:
+- Swaps GPIO pin for LEDs 1 and 4, since I burned out GPIO4
+- Adds a *wol* type, which takes a MAC address as *data* and broadcasts a magic packet
+
+A function to convert the NECx IR format to the HEX format used in the ESP code is also inclued. You can compile and run it using CMake:
+```
+mkdir build
+cd build
+cmake ..
+make
+./convert
+```
+or using a simple `g++` command:
+```
+g++ convert.C -o convert
+./convert
+```
+
 # ESP8266-HTTP-IR-Blaster V2
 ==============
 ESP8266 Compatible IR Blaster that accepts HTTP commands for use with services like Amazon Echo

--- a/convert.cxx
+++ b/convert.cxx
@@ -1,0 +1,41 @@
+#include <iostream>
+
+// Found raw at: http://www.avsforum.com/forum/166-lcd-flat-panel-displays/1936145-samsung-un24h4500afxza-toggle-discrete-power-off-switching-inputs.html
+// Converted using: http://irdb.tk/decode/
+
+// Reverse the order of bits in a byte
+// Example: 01000000 -> 00000010
+unsigned char ReverseByte(unsigned char b)
+{
+  b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
+  b = (b & 0xCC) >> 2 | (b & 0x33) << 2;
+  b = (b & 0xAA) >> 1 | (b & 0x55) << 1;
+  return(b);
+}
+
+// Calculate 32 bit NECx code
+unsigned long GenNECXCode(unsigned char p_Device, unsigned char p_SubDevice, unsigned char p_Function)
+{
+  unsigned long ReverseDevice = (unsigned long)ReverseByte(p_Device);
+  unsigned long ReverseSubDevice = (unsigned long)ReverseByte(p_SubDevice);
+  unsigned long ReverseFunction = (unsigned long)ReverseByte(p_Function);
+  return((ReverseDevice << 24) | (ReverseSubDevice << 16) | (ReverseFunction << 8) | ((~ReverseFunction) & 0xFF));
+}
+
+int main(int argc, char *argv[])
+{
+  int SAMSUNG_BITS = 32;
+  unsigned long SAMSUNG_POWER_ON = GenNECXCode(7,7,153); // Discrete ON
+  unsigned long SAMSUNG_POWER_OFF = GenNECXCode(7,7,152); // Discrete OFF
+  unsigned long SAMSUNG_SRC_HDMI1 = GenNECXCode(7,7,233); // HDMI 1
+  unsigned long SAMSUNG_SRC_HDMI2 = GenNECXCode(7,7,190); // HDMI 2
+  unsigned long SAMSUNG_SRC_HDMI3 = GenNECXCode(7,7,194); // HDMI 2
+
+  std::cout << "on --> SAMSUNG:" << std::hex << SAMSUNG_POWER_ON << ":" << std::dec << SAMSUNG_BITS << std::endl;
+  std::cout << "off --> SAMSUNG:" << std::hex << SAMSUNG_POWER_OFF << ":" << std::dec << SAMSUNG_BITS << std::endl;
+  std::cout << "hdmi1 --> SAMSUNG:" << std::hex << SAMSUNG_SRC_HDMI1 << ":" << std::dec << SAMSUNG_BITS << std::endl;
+  std::cout << "hdmi2 --> SAMSUNG:" << std::hex << SAMSUNG_SRC_HDMI2 << ":" << std::dec << SAMSUNG_BITS << std::endl;
+  std::cout << "hdmi3 --> SAMSUNG:" << std::hex << SAMSUNG_SRC_HDMI3 << ":" << std::dec << SAMSUNG_BITS << std::endl;
+
+  // irsend.sendSAMSUNG(SAMSUNG_POWER_ON, SAMSUNG_BITS);
+}


### PR DESCRIPTION
Swapped GPIO pins since I burned out the default pin for LED1. Users can now specify type=wol and data=MAC in order to broadcast a magic wake-on-lan packet. A simple executable for converting from NECx IR format to the HEX format used by the ESP code is also included.